### PR TITLE
Add links to PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This repo showcases how the entries are being built, how to exclude them, and ho
 2. `git co -b release/1.0.1`, make a commit there, tag `1.0.1`, and release, but don't make a PR yet!
 ### Woorelease
 Create and merge a PR
-1. (set type) with a body containing 
+1. [(set type - manual)](https://github.com/woorelease-bugs/types-excludes/pull/2) with a body containing 
 	```md
 	### Changelog entry
 
-	> Add - Added entry.
+	> Add - release.yml
 	```
 2. (exclude) with a body finishing with
 	```md
@@ -24,13 +24,13 @@ Create and merge a PR
 	> Add - One change.
 	> Fix - Second change.
 	```
-3. with a body containing
+3. [(problematic exclude)](https://github.com/woorelease-bugs/types-excludes/pull/1) with a body containing
 	```md
 	### Changelog entry
-	some leftover text
+	some leftover
 	```
 4. (fall back to PR name) without any `### Changelog entry` section in the body
-5. (problematic fallback) merging `release/1.0.1` branch with `Release 1.0.1` as a title, and no `### Changelog entry` section in the body
+5. [(problematic fallback)](https://github.com/woorelease-bugs/types-excludes/pull/3) merging `release/1.0.1` branch with `Release 1.0.1` as a title, and no `### Changelog entry` section in the body
 6. Generate chengelog with
 	```
 	woorelease cl:generate --product_version=1.0.2 https://github.com/woorelease-bugs/types-excludes/tree/develop
@@ -38,11 +38,11 @@ Create and merge a PR
 
 ### GitHub config
 Create and merge a PR
-1. (set type - automatic) from a branch prefixed `add/`, `fix/`, `remove/`, `update/`, or `tweak/`
-1. (set type - manual) from any branch and assign a GH label `changelog: fix|add|update|tweak`
+1. [(set type - automatic)](https://github.com/woorelease-bugs/types-excludes/pull/2) from a branch prefixed `add/`, `fix/`, `remove/`, `update/`, or `tweak/`
+1. [(set type - manual)](https://github.com/woorelease-bugs/types-excludes/pull/4) from any branch and assign a GH label `changelog: fix|add|update|tweak`
 2. (exclude) and assign a GH label `changelog: none`
-4. (fall for no label) from a non-prefixed branch and without any label
-5. (automatically excluded releases) merging `release/*`
+4. (fall back for no label) from a non-prefixed branch and without any label
+5. [(automatically excluded releases)](https://github.com/woorelease-bugs/types-excludes/pull/3) merging `release/*`
 6. Go to https://github.com/woorelease-bugs/types-excludes/releases/new?tag=1.0.2 and click "Generate release notes"
 
 ## Prerequisites


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a fallback test:
- for `woorelease` when there is no `Changelog entry` section, it will fall back to PR title
- for GH release notes, the lack of `changelog: *` label, will make it fall to the default category

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
